### PR TITLE
Namespace collision with $red, $green and $blue

### DIFF
--- a/blend-mode.scss
+++ b/blend-mode.scss
@@ -2,36 +2,36 @@
 // Normal
 //--------------------------------
 @function blend-normal ($blend, $base) {
-	$opacity: opacity($blend);
-	$base-opacity: opacity($base);
+  $opacity: opacity($blend);
+  $base-opacity: opacity($base);
 
-	// calculate opacity
-	$red: red($blend) * $opacity + red($base) * $base-opacity * (1 - $opacity);
-	$green: green($blend) * $opacity + green($base) * $base-opacity * (1 - $opacity);
-	$blue: blue($blend) * $opacity + blue($base) * $base-opacity * (1 - $opacity);
-	@return rgb($red, $green, $blue);
+  // calculate opacity
+  $bm-red: red($blend) * $opacity + red($base) * $base-opacity * (1 - $opacity);
+  $bm-green: green($blend) * $opacity + green($base) * $base-opacity * (1 - $opacity);
+  $bm-blue: blue($blend) * $opacity + blue($base) * $base-opacity * (1 - $opacity);
+  @return rgb($bm-red, $bm-green, $bm-blue);
 }
 
 //--------------------------------
 // Multiply
 //--------------------------------
 @function blend-multiply ($blend, $base) {
-	$red: red($base) * red($blend) / 255;
-	$green: green($base) * green($blend) / 255;
-	$blue: blue($base) * blue($blend) / 255;
-	
-	@return blend-normal(rgba($red, $green, $blue, opacity($blend)), $base);
+  $bm-red: red($base) * red($blend) / 255;
+  $bm-green: green($base) * green($blend) / 255;
+  $bm-blue: blue($base) * blue($blend) / 255;
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($blend)), $base);
 }
 
 //--------------------------------
 // Lighten
 //--------------------------------
 @function blend-lighten ($blend, $base) {
-  $red: blend-lighten-color(red($blend), red($base));
-  $green: blend-lighten-color(green($blend), green($base));
-  $blue: blend-lighten-color(blue($blend), blue($base));
-  
-  @return blend-normal(rgba($red, $green, $blue, opacity($blend)), $base);
+  $bm-red: blend-lighten-color(red($blend), red($base));
+  $bm-green: blend-lighten-color(green($blend), green($base));
+  $bm-blue: blend-lighten-color(blue($blend), blue($base));
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($blend)), $base);
 }
 @function blend-lighten-color($blend, $base) {
   @if $base > $blend {
@@ -44,11 +44,11 @@
 // Darken
 //--------------------------------
 @function blend-darken ($blend, $base) {
-  $red: blend-darken-color(red($blend), red($base));
-  $green: blend-darken-color(green($blend), green($base));
-  $blue: blend-darken-color(blue($blend), blue($base));
-  
-	@return blend-normal(rgba($red, $green, $blue, opacity($blend)), $base);
+  $bm-red: blend-darken-color(red($blend), red($base));
+  $bm-green: blend-darken-color(green($blend), green($base));
+  $bm-blue: blend-darken-color(blue($blend), blue($base));
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($blend)), $base);
 }
 @function blend-darken-color($blend, $base) {
   @if $base < $blend {
@@ -61,49 +61,49 @@
 // Darker Color
 //--------------------------------
 @function blend-darkercolor ($blend, $base) {
-	$red: red($blend);
-	$green: green($blend);
-	$blue: blue($blend);
-	$base-red: red($base);
-	$base-green: green($base);
-	$base-blue: blue($base);
-	
-	@if $base-red * 0.3 + $base-green * 0.59 + $base-blue * 0.11 <= $red * 0.3 + $green * 0.59 + $blue * 0.11 {
-		$red: $base-red;
-		$green: $base-green;
-		$blue: $base-blue;
-	}
-	@return blend-normal(rgba($red, $green, $blue, opacity($blend)), $base);
+  $bm-red: red($blend);
+  $bm-green: green($blend);
+  $bm-blue: blue($blend);
+  $base-red: red($base);
+  $base-green: green($base);
+  $base-blue: blue($base);
+
+  @if $base-red * 0.3 + $base-green * 0.59 + $base-blue * 0.11 <= $bm-red * 0.3 + $bm-green * 0.59 + $bm-blue * 0.11 {
+    $bm-red: $base-red;
+    $bm-green: $base-green;
+    $bm-blue: $base-blue;
+  }
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($blend)), $base);
 }
 
 //--------------------------------
 // Lighter Color
 //--------------------------------
 @function blend-lightercolor ($blend, $base) {
-	$red: red($blend);
-	$green: green($blend);
-	$blue: blue($blend);
-	$base-red: red($base);
-	$base-green: green($base);
-	$base-blue: blue($base);
-	
-	@if $base-red * 0.3 + $base-green * 0.59 + $base-blue * 0.11 > $red * 0.3 + $green * 0.59 + $blue * 0.11 {
-		$red: $base-red;
-		$green: $base-green;
-		$blue: $base-blue;
-	}
-	@return blend-normal(rgba($red, $green, $blue, opacity($blend)), $base);
+  $bm-red: red($blend);
+  $bm-green: green($blend);
+  $bm-blue: blue($blend);
+  $base-red: red($base);
+  $base-green: green($base);
+  $base-blue: blue($base);
+
+  @if $base-red * 0.3 + $base-green * 0.59 + $base-blue * 0.11 > $bm-red * 0.3 + $bm-green * 0.59 + $bm-blue * 0.11 {
+    $bm-red: $base-red;
+    $bm-green: $base-green;
+    $bm-blue: $base-blue;
+  }
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($blend)), $base);
 }
 
 //--------------------------------
 // Linear Dodge
 //--------------------------------
 @function blend-lineardodge ($blend, $base) {
-  $red: blend-lineardodge-color(red($blend), red($base));
-  $green: blend-lineardodge-color(green($blend), green($base));
-  $blue: blend-lineardodge-color(blue($blend), blue($base));
-  
-	@return blend-normal(rgba($red, $green, $blue, opacity($blend)), $base);
+  $bm-red: blend-lineardodge-color(red($blend), red($base));
+  $bm-green: blend-lineardodge-color(green($blend), green($base));
+  $bm-blue: blend-lineardodge-color(blue($blend), blue($base));
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($blend)), $base);
 }
 @function blend-lineardodge-color($blend, $base) {
   @if $base + $blend > 255 {
@@ -119,11 +119,11 @@
 // Linear Burn
 //--------------------------------
 @function blend-linearburn ($blend, $base) {
-  $red: blend-linearburn-color(red($blend), red($base));
-  $green: blend-linearburn-color(green($blend), green($base));
-  $blue: blend-linearburn-color(blue($blend), blue($base));
-  
-	@return blend-normal(rgba($red, $green, $blue, opacity($blend)), $base);
+  $bm-red: blend-linearburn-color(red($blend), red($base));
+  $bm-green: blend-linearburn-color(green($blend), green($base));
+  $bm-blue: blend-linearburn-color(blue($blend), blue($base));
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($blend)), $base);
 }
 @function blend-linearburn-color($blend, $base) {
   @if $base + $blend < 255 {
@@ -139,58 +139,58 @@
 // Difference
 //--------------------------------
 @function blend-difference ($blend, $base) {
-	$red: abs(red($base) - red($blend));
-	$green: abs(green($base) - green($blend));
-	$blue: abs(blue($base) - blue($blend));
-	
-	@return blend-normal(rgba($red, $green, $blue, opacity($blend)), $base);
+  $bm-red: abs(red($base) - red($blend));
+  $bm-green: abs(green($base) - green($blend));
+  $bm-blue: abs(blue($base) - blue($blend));
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($blend)), $base);
 }
 
 //--------------------------------
 // Screen
 //--------------------------------
 @function blend-screen ($blend, $base) {
-	$red: red($blend);
-	$green: green($blend);
-	$blue: blue($blend);
-	$base-red: red($base);
-	$base-green: green($base);
-	$base-blue: blue($base);
-	
+  $bm-red: red($blend);
+  $bm-green: green($blend);
+  $bm-blue: blue($blend);
+  $base-red: red($base);
+  $base-green: green($base);
+  $base-blue: blue($base);
 
-	$red: (255 - ( ((255 - $red) * (255 - $base-red)) / 256));
-	$green: (255 - ( ((255 - $green) * (255 - $base-green)) / 256));
-	$blue: (255 - ( ((255 - $blue) * (255 - $base-blue)) / 256));
-	@return blend-normal(rgba($red, $green, $blue, opacity($blend)), $base);
+
+  $bm-red: (255 - ( ((255 - $bm-red) * (255 - $base-red)) / 256));
+  $bm-green: (255 - ( ((255 - $bm-green) * (255 - $base-green)) / 256));
+  $bm-blue: (255 - ( ((255 - $bm-blue) * (255 - $base-blue)) / 256));
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($blend)), $base);
 }
 
 //--------------------------------
 // Exclusion
 //--------------------------------
 @function blend-exclusion ($blend, $base) {
-	$red: red($blend);
-	$green: green($blend);
-	$blue: blue($blend);
-	$base-red: red($base);
-	$base-green: green($base);
-	$base-blue: blue($base);
-	
+  $bm-red: red($blend);
+  $bm-green: green($blend);
+  $bm-blue: blue($blend);
+  $base-red: red($base);
+  $base-green: green($base);
+  $base-blue: blue($base);
 
-	$red: $base-red - ($base-red * $blend-div - 1) * $red;
-	$green: $base-green - ($base-green * $blend-div - 1) * $green;
-	$blue: $base-blue - ($base-blue * $blend-div - 1) * $blue;
-	@return blend-normal(rgba($red, $green, $blue, opacity($blend)), $base);
+
+  $bm-red: $base-red - ($base-red * $blend-div - 1) * $bm-red;
+  $bm-green: $base-green - ($base-green * $blend-div - 1) * $bm-green;
+  $bm-blue: $base-blue - ($base-blue * $blend-div - 1) * $bm-blue;
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($blend)), $base);
 }
 
 //--------------------------------
 // Overlay
 //--------------------------------
 @function blend-overlay ($blend, $base) {
-  $red: blend-overlay-color(red($blend), red($base));
-  $green: blend-overlay-color(green($blend), green($base));
-  $blue: blend-overlay-color(blue($blend), blue($base));
-  
-	@return blend-normal(rgba($red, $green, $blue, opacity($blend)), $base);
+  $bm-red: blend-overlay-color(red($blend), red($base));
+  $bm-green: blend-overlay-color(green($blend), green($base));
+  $bm-blue: blend-overlay-color(blue($blend), blue($base));
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($blend)), $base);
 }
 @function blend-overlay-color($blend, $base) {
   @if $base <= 255 / 2 {
@@ -205,11 +205,11 @@
 // Soft Light
 //--------------------------------
 @function blend-softlight ($blend, $base) {
-  $red: blend-softlight-color(red($blend), red($base));
-  $green: blend-softlight-color(green($blend), green($base));
-  $blue: blend-softlight-color(blue($blend), blue($base));
-  
-	@return blend-normal(rgba($red, $green, $blue, opacity($blend)), $base);
+  $bm-red: blend-softlight-color(red($blend), red($base));
+  $bm-green: blend-softlight-color(green($blend), green($base));
+  $bm-blue: blend-softlight-color(blue($blend), blue($base));
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($blend)), $base);
 }
 @function blend-softlight-color($blend, $base) {
   @if $base < 128 {
@@ -224,11 +224,11 @@
 // Hard Light
 //--------------------------------
 @function blend-hardlight ($blend, $base) {
-  $red: blend-hardlight-color(red($blend), red($base));
-  $green: blend-hardlight-color(green($blend), green($base));
-  $blue: blend-hardlight-color(blue($blend), blue($base));
-  
-  @return blend-normal(rgba($red, $green, $blue, opacity($blend)), $base);
+  $bm-red: blend-hardlight-color(red($blend), red($base));
+  $bm-green: blend-hardlight-color(green($blend), green($base));
+  $bm-blue: blend-hardlight-color(blue($blend), blue($base));
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($blend)), $base);
 }
 @function blend-hardlight-color($blend, $base) {
   $tmp-blend: $blend;
@@ -244,11 +244,11 @@
 // Color Dodge
 //--------------------------------
 @function blend-colordodge ($blend, $base) {
-  $red: blend-colordodge-color(red($blend), red($base));
-  $green: blend-colordodge-color(green($blend), green($base));
-  $blue: blend-colordodge-color(blue($blend), blue($base));
-  
-	@return blend-normal(rgba($red, $green, $blue, opacity($blend)), $base);
+  $bm-red: blend-colordodge-color(red($blend), red($base));
+  $bm-green: blend-colordodge-color(green($blend), green($base));
+  $bm-blue: blend-colordodge-color(blue($blend), blue($base));
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($blend)), $base);
 }
 @function blend-colordodge-color($blend, $base) {
   $tmp: $base * 256 / (255 - $blend);
@@ -264,15 +264,15 @@
 // Color Burn
 //--------------------------------
 @function blend-colorburn ($blend, $base) {
-  $red: blend-colorburn-color(red($blend), red($base));
-  $green: blend-colorburn-color(green($blend), green($base));
-  $blue: blend-colorburn-color(blue($blend), blue($base));
+  $bm-red: blend-colorburn-color(red($blend), red($base));
+  $bm-green: blend-colorburn-color(green($blend), green($base));
+  $bm-blue: blend-colorburn-color(blue($blend), blue($base));
 
-	@return blend-normal(rgba($red, $green, $blue, opacity($blend)), $base);
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($blend)), $base);
 }
 @function blend-colorburn-color($blend, $base) {
   $tmp: (256 - ((255 - $base) * 256) / $blend);
-  
+
   // TODO: hacked to replicate photoshop
   @if $blend == 0 {
     $blend: 255;
@@ -288,11 +288,11 @@
 // Linear Light
 //--------------------------------
 @function blend-linearlight ($blend, $base) {
-	$red: blend-linearlight-color(red($blend), red($base));
-	$green: blend-linearlight-color(green($blend), green($base));
-	$blue: blend-linearlight-color(blue($blend), blue($base));
+  $bm-red: blend-linearlight-color(red($blend), red($base));
+  $bm-green: blend-linearlight-color(green($blend), green($base));
+  $bm-blue: blend-linearlight-color(blue($blend), blue($base));
 
-	@return blend-normal(rgba($red, $green, $blue, opacity($blend)), $base);
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($blend)), $base);
 }
 @function blend-linearlight-color($blend, $base) {
   @if $blend < 128 {
@@ -307,11 +307,11 @@
 // Vivid Light
 //--------------------------------
 @function blend-vividlight ($blend, $base) {
-	$red: blend-vividlight-color(red($blend), red($base));
-	$green: blend-vividlight-color(green($blend), green($base));
-	$blue: blend-vividlight-color(blue($blend), blue($base));
-	
-	@return blend-normal(rgba($red, $green, $blue, opacity($blend)), $base);
+  $bm-red: blend-vividlight-color(red($blend), red($base));
+  $bm-green: blend-vividlight-color(green($blend), green($base));
+  $bm-blue: blend-vividlight-color(blue($blend), blue($base));
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($blend)), $base);
 }
 
 @function blend-vividlight-color($blend, $base) {
@@ -327,11 +327,11 @@
 // Pin Light
 //--------------------------------
 @function blend-pinlight ($blend, $base) {
-  $red:   blend-pinlight-color(red($blend), red($base));
-  $green: blend-pinlight-color(green($blend), green($base));
-  $blue:  blend-pinlight-color(blue($blend), blue($base));
-  
-	@return blend-normal(rgba($red, $green, $blue, opacity($blend)), $base);
+  $bm-red:   blend-pinlight-color(red($blend), red($base));
+  $bm-green: blend-pinlight-color(green($blend), green($base));
+  $bm-blue:  blend-pinlight-color(blue($blend), blue($base));
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($blend)), $base);
 }
 
 @function blend-pinlight-color($blend, $base) {
@@ -347,11 +347,11 @@
 // Hard Mix
 //--------------------------------
 @function blend-hardmix ($blend, $base) {
-  $red: blend-hardmix-color(red($blend), red($base));
-  $green: blend-hardmix-color(green($blend), green($base));
-  $blue: blend-hardmix-color(blue($blend), blue($base));
-  
-	@return blend-normal(rgba($red, $green, $blue, opacity($blend)), $base);
+  $bm-red: blend-hardmix-color(red($blend), red($base));
+  $bm-green: blend-hardmix-color(green($blend), green($base));
+  $bm-blue: blend-hardmix-color(blue($blend), blue($base));
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($blend)), $base);
 }
 
 @function blend-hardmix-color($blend, $base) {


### PR DESCRIPTION
Thanks for the great mixins.  I received errors when trying to pass in color variables named $red, $green or $blue.  I replaced those internal variable names in the mixins with $bm-red, $bm-green or $bm-blue and all is well again.

For reference the error was "Line 189 of sass/partials/_blend-mode.scss: 163.75 is not a color for `red'"
